### PR TITLE
Adding GetFields function to logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ func AddFields(ctx context.Context, newFields Fields)
 AddFields adds new fields to the logger contained in ctx. Existing fields might
 be overwritten.
 
+#### func  GetFields
+
+```go
+func GetFields() Fields
+```
+GetFields returns the fields of the logger contained in ctx.
+
 #### func  Alert
 
 ```go

--- a/golog.go
+++ b/golog.go
@@ -41,6 +41,12 @@ func AddFields(ctx context.Context, newFields Fields) {
 	l.AddFields(newFields)
 }
 
+// GetFields retrieves the fields to the logger contained in ctx.
+func GetFields(ctx context.Context) Fields {
+	l := GetLogger(ctx)
+	return l.GetFields()
+}
+
 // Debug outputs a debug log message using the logger contained in ctx.
 // If ctx doesn't contain a logger, it uses a new logger.
 func Debug(ctx context.Context, msg string, req *HTTPRequest, fields Fields) {

--- a/golog.go
+++ b/golog.go
@@ -41,7 +41,7 @@ func AddFields(ctx context.Context, newFields Fields) {
 	l.AddFields(newFields)
 }
 
-// GetFields retrieves the fields to the logger contained in ctx.
+// GetFields returns the fields of the logger contained in ctx.
 func GetFields(ctx context.Context) Fields {
 	l := GetLogger(ctx)
 	return l.GetFields()

--- a/logger.go
+++ b/logger.go
@@ -62,6 +62,11 @@ func (l *Logger) AddFields(newFields Fields) {
 	}
 }
 
+// GetFields returns the fields of the logger.
+func (l *Logger) GetFields() Fields {
+	return l.fields
+}
+
 // Debug outputs a debug log message.
 func (l *Logger) Debug(msg string, req *HTTPRequest, fields Fields) {
 	l.output(levelDebug, msg, req, fields)


### PR DESCRIPTION
Adding a GetFields function to the logger, so that in the case of context switching and/or creating new loggers for child contexts, the fields of the existing logger can be retrieved and passed on.